### PR TITLE
Restore original Interdictor functionality

### DIFF
--- a/DarkSpace/FieldInterdictor.cpp
+++ b/DarkSpace/FieldInterdictor.cpp
@@ -1,6 +1,6 @@
 /*
-	FieldInterdictor.cpp
-	(c)2004 Palestar Inc, Richard Lyle
+    FieldInterdictor.cpp
+    (c)2004 Palestar Inc, Richard Lyle
 */
 
 
@@ -9,13 +9,13 @@
 #include "GadgetJD.h"
 #include "NounShip.h"
 #include "VerbJumpAbort.h"
-#include "resource.h"
+#include "Resource.h"
 #include "GameContext.h"
 
 //----------------------------------------------------------------------------
 
 IMPLEMENT_FACTORY( FieldInterdictor, NounField );
-REGISTER_FACTORY_KEY( FieldInterdictor, 4635880574829179581LL );
+REGISTER_FACTORY_KEY( FieldInterdictor, 4635880574829179581 );
 
 BEGIN_PROPERTY_LIST( FieldInterdictor, NounField )
 END_PROPERTY_LIST();
@@ -27,7 +27,11 @@ FieldInterdictor::FieldInterdictor()
 
 void FieldInterdictor::simulate( dword nTick )
 {
-	NounField::simulate( nTick );
+    // verify that our GadgeJD device is linked to this field, this removes orphaned fields
+    if ( WidgetCast<GadgetJD>( link() ) )
+        if ( ((GadgetJD *)link())->field() != this )
+            setLink( NULL );
+    NounField::simulate( nTick );
 }
 
 //----------------------------------------------------------------------------
@@ -37,43 +41,44 @@ void FieldInterdictor::onEnterField( Noun * pNoun )
 
 void FieldInterdictor::onInsideField( Noun * pNoun )
 {
-	if ( WidgetCast<NounShip>( pNoun ) )
-	{
-		NounShip * pShip = (NounShip *)pNoun;
+    if ( m_pLink.valid() && WidgetCast<NounShip>( pNoun ) )
+    {
+        NounShip * pShip = (NounShip *)pNoun;
 
-		// disable any non-friendly ships inside the field...
-		if ( ! isFriend( pShip ) )
-		{
-			if ( !pShip->testFlags( NounShip::FLAG_JUMP_DISABLED ) )	// no need to disable, if already disabled
-			{
-				pShip->addFlags( NounShip::FLAG_JUMP_DISABLED );
+        // disable any non-friendly ships inside the field...
+	    if ( ! m_pLink->isFriend( pShip ) )
+        {
+            if ( !pShip->testFlags( NounShip::FLAG_JUMP_DISABLED ) )    // no need to disable, if already disabled
+            {
+                pShip->message( "<color;ffffff>Helm: Jump drives disabled by interdictor.." );
+                pShip->addFlags( NounShip::FLAG_JUMP_DISABLED );
 
-				if ( pShip->isLocal() )
-				{
-					pShip->message( "<color;ffffff>Helm: Jump drives disabled by interdictor.." );
-					GadgetJumpDrive * pJD = pShip->jumpDrive();
-					if ( pJD != NULL && (pJD->engaged() || pJD->jumping()) )
-						Verb::Ref( new VerbJumpAbort( pShip ) );
-				}
-			}
-		}
-		// This causes the interdictor message spam when a friendly and enemy fields overlap each other... leave it off.
-		//else if ( pShip->testFlags( NounShip::FLAG_JUMP_DISABLED ) )
-		//{
-		//	// ship is no longer an enemy ship, enable jump drives..
-		//	pShip->clearFlags( NounShip::FLAG_JUMP_DISABLED );
-		//}
-	}
+                if ( server() )
+                {
+                    // abort the jump if any
+                    if ( pShip->jumpDrive() != NULL && (pShip->jumpDrive()->engaged() || pShip->jumpDrive()->jumping()) )
+                        Verb::Ref( new VerbJumpAbort( pShip ) );
+                }
+            }
+        }
+        /*
+        else if ( pShip->testFlags( NounShip::FLAG_JUMP_DISABLED ) )
+        {
+            // ship is no longer an enemy ship, enable jump drives..
+            pShip->clearFlags( NounShip::FLAG_JUMP_DISABLED );
+        }
+        */
+    }
 }
 
 void FieldInterdictor::onLeaveField( Noun * pNoun )
 {
-	if ( WidgetCast<NounShip>( pNoun ) )
-	{
-		NounShip * pShip = (NounShip *)pNoun;
-		// ship has left interdictor field, enable jump drive
-		pShip->clearFlags( NounShip::FLAG_JUMP_DISABLED );
-	}
+    if ( WidgetCast<NounShip>( pNoun ) )
+    {
+        NounShip * pShip = (NounShip *)pNoun;
+        // ship has left interdictor field, enable jump drive
+        pShip->clearFlags( NounShip::FLAG_JUMP_DISABLED );
+    }
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Community members have requested that planetary Interdictors function the way they did in previous versions. This is unedited code of the original working Interdictor that will restore that functionality. Also see changes in GadgetJD.cpp and GadgetJD.h