### PR TITLE
Restore original Interdictor functionality

### DIFF
--- a/DarkSpace/GadgetJD.h
+++ b/DarkSpace/GadgetJD.h
@@ -1,6 +1,6 @@
 /*
-	GadgetJD.h
-	(c)2000 Palestar Inc, Richard Lyle
+    GadgetJD.h
+    (c)2000 Palestar Inc, Richard Lyle
 */
 
 #ifndef GADGETJD_H
@@ -17,61 +17,55 @@
 class DLL GadgetJD : public NounGadget
 {
 public:
-	DECLARE_WIDGET_CLASS();
-	DECLARE_PROPERTY_LIST();
+    DECLARE_WIDGET_CLASS();
+    DECLARE_PROPERTY_LIST();
 
-	// Construction
-	GadgetJD();
+    // Construction
+    GadgetJD();
 
-	// BaseNode interface
-	void					render( RenderContext &context, 
-								const Matrix33 & frame, 
-								const Vector3 & position );			
-	// Noun interface
-	void					initialize();
-	void					release();
-	// NounGadget interface
-	Type					type() const;					// get gadget type
-	dword					hotkey() const;					// gadget hotkey
-	
-	float					addMass() const;				// mass of this gadget	
+    // BaseNode interface
+    void                    render( RenderContext &context, 
+                                const Matrix33 & frame, 
+                                const Vector3 & position );
+    // Noun interface
+    void                    release();
+    // NounGadget interface
+    Type                    type() const;                    // get gadget type
+    dword                    hotkey() const;                    // gadget hotkey
 
-	float					addSignature() const;			// add signature when active
+    float                    addSignature() const;            // add signature when active
 
-	bool					usable( Noun * pTarget, 
-								bool shift ) const;			// can gadget be used on target
-	bool					useActive() const;				// is the gadget current on or off
-	void					use( dword when, Noun * pTarget,
-								bool shift);				// use gadget
-	int						useEnergy( dword nTick, 
-								int energy );				// use energy
-	bool					updateLogic();
+    bool                    usable( Noun * pTarget, 
+                                bool shift ) const;            // can gadget be used on target
+    bool                    useActive() const;                // is the gadget current on or off
+    void                    use( dword when, Noun * pTarget,
+                                bool shift);                // use gadget
+    int                        useEnergy( dword nTick, 
+                                int energy );                // use energy
+    bool                    updateLogic();
+    // Accessors
+    bool                    active() const;                    // how many ticks remaining
+    FieldInterdictor *        field() const;
 
-	// Accessors
-	bool					active() const;					// how many ticks remaining
-	FieldInterdictor *		field() const;	
-
-	virtual int				energyCost() const = 0;
-	virtual float			range() const = 0;
+    virtual int                energyCost() const = 0;
+    virtual float            range() const = 0;
 
 private:
-	//! Data
-	FieldInterdictor::wRef	m_pField;
-	// non-serialized
-	int						m_nLastFleetId;					// our last fleet id
-	float					m_fFieldScale;
+    // non-serialized
+    FieldInterdictor::wRef    m_pField;
+    int                        m_nLastFleetId;                    // our last fleet id
 };
 
 //----------------------------------------------------------------------------
 
 inline bool GadgetJD::active() const
 {
-	return (flags() & FLAG_ACTIVE) != 0;
+    return (flags() & FLAG_ACTIVE) != 0;
 }
 
 inline FieldInterdictor * GadgetJD::field() const
 {
-	return m_pField;
+    return m_pField;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Community members have requested that planetary Interdictors function the way they did in previous versions. This is unedited code of the original working Interdictor that will restore that functionality. Also see changes in GadgetJD.cpp and FieldInterdictor.cpp