### PR TITLE
Restore original Interdictor functionality

### DIFF
--- a/DarkSpace/GadgetJD.cpp
+++ b/DarkSpace/GadgetJD.cpp
@@ -1,6 +1,6 @@
 /*
-	GadgetJD.cpp
-	(c)2000 Palestar Inc, Richard Lyle
+    GadgetJD.cpp
+    (c)2000 Palestar Inc, Richard Lyle
 */
 
 
@@ -8,7 +8,7 @@
 #include "GadgetJD.h"
 #include "VerbJumpAbort.h"
 #include "GameContext.h"
-#include "resource.h"
+#include "Resource.h"
 #include "StructureDefense.h"
 #include "VerbGadgetOff.h"
 
@@ -19,162 +19,127 @@ const dword GADGETJD_STEP_RATE = TICKS_PER_SECOND * 3;
 //----------------------------------------------------------------------------
 
 IMPLEMENT_ABSTRACT_FACTORY( GadgetJD, NounGadget ); 
-REGISTER_FACTORY_KEY( GadgetJD, 4346018582041573986LL );
+REGISTER_FACTORY_KEY( GadgetJD, 4346018582041573986 );
 
 BEGIN_ABSTRACT_PROPERTY_LIST( GadgetJD, NounGadget );
-	//ADD_TRANSMIT_UPDATE_PROPERTY( m_Children );
 END_PROPERTY_LIST();
 
-GadgetJD::GadgetJD() : m_nLastFleetId( -1 ), m_fFieldScale( 1.0f )
+GadgetJD::GadgetJD() : m_nLastFleetId( -1 )
 {}
 
 //----------------------------------------------------------------------------
 
 void GadgetJD::render( RenderContext &context, 
-				const Matrix33 & frame, 
-				const Vector3 & position )
-{	
-	Scene * pUseEffect = useEffect();
-	if ( active() && pUseEffect != NULL )
-		pUseEffect->render( context, Matrix33::IDENTITY * m_fFieldScale, position );		
+                const Matrix33 & frame, 
+                const Vector3 & position )
+{
+    if ( active() )
+    {
+        Scene * pUseEffect = useEffect();
+        if ( pUseEffect != NULL )
+            pUseEffect->render( context, frame, position );
+    }
 }
 
 //----------------------------------------------------------------------------
 
-void GadgetJD::initialize()
-{
-	NounGadget::initialize();
-
-	m_pField = NULL;
-	NounField::removeAllFields( this );
-}
-
 void GadgetJD::release()
 {
-	NounGadget::release();
+    NounGadget::release();
+    if ( m_pField.valid() )
+        m_pField->setLink( NULL );
 }
-
 //----------------------------------------------------------------------------
 
 NounGadget::Type GadgetJD::type() const
 {
-	return INTERDICTOR;
+    return INTERDICTOR;
 }
 
 dword GadgetJD::hotkey() const
 {
-	return 'I';
+    return 'I';
 }
 
 float GadgetJD::addSignature() const
 {
-	return active() ? 9.0f : 0.0f;
+    return active() ? 9.0f : 0.0f;
 }
 
 bool GadgetJD::usable( Noun * pTarget, bool shift ) const
 {
-	if ( active() )
-		return true;
-	if (! NounGadget::usable( pTarget, shift ) )
-		return false;
-	if ( destroyed() )
-		return false;
-	if ( isCloaked() || isSafeZone() )
-		return false;
-	return true;
+    if ( active() )
+        return true;
+    if ( destroyed() )
+        return false;
+    if ( isCloaked() || isSafeZone() )
+        return false;
+    return true;
 }
 
 bool GadgetJD::useActive() const
 {
-	return active();
+    return active();
 }
 
 void GadgetJD::use( dword when, Noun * pTarget, bool shift)
 {
-	if ( active() )
-		NounGadget::use( when, pTarget, shift );
-
-	// set the device active
-	setFlags( FLAG_ACTIVE, !active() );
-	message( CharString().format( "<color;ffffff>Tactical: %s %s.", name(), active() ? "Active" : "Inactive" ) ); 
+    // set the device active
+    setFlags( FLAG_ACTIVE, !active() );
+    message( CharString().format( "<color;ffffff>Tactical: %s %s.", name(), active() ? "Active" : "Inactive" ) ); 
 }
-
 int GadgetJD::useEnergy( dword nTick, int energy )
 {
-	if ( active() )
-	{
-		if ( !m_pField.valid() || m_nLastFleetId != teamId() )
-		{
-			// if the old field is still here due to ownership change, we need to null it before we setup a new one
-			if ( m_pField.valid() )
-			{
-				detachNode( m_pField );
-				m_pField = NULL;		
-			}
-			m_nLastFleetId = teamId();
+    if ( active() )
+    {
+        if ( !m_pField.valid() || m_nLastFleetId != teamId() )
+        {
+            m_nLastFleetId = teamId();
 
-			m_pField = new FieldInterdictor;
-			m_pField->setName( "Jump Disruption Field" );
+            m_pField = new FieldInterdictor;
+            m_pField->setName( "Jump Distruption Field" );
+            m_pField->setPosition( zonePosition() );
+            m_pField->setFieldRadius( range() );
+            m_pField->setLink( this );
 
-			float fRange = range();
+            zone()->attachNoun( m_pField );
+        }
 
-			if ( WidgetCast<StructureDefense>( parent() ) )
-			{
-				NounPlanet * pPlanet = ((StructureDefense *)parent())->planet();
-				m_fFieldScale = ( range() + pPlanet->radius() ) / range();
-				m_pField->setFieldRadius( fRange * m_fFieldScale );			
-				
-				attachNode( m_pField );
-				m_pField->setWorldPosition( pPlanet->worldPosition() );
-			}
-			else
-			{
-				m_fFieldScale = 1.0f;
-				m_pField->setFieldRadius( fRange );			
-				attachNode( m_pField );
-			}
-		}
+        energy -= energyCost();
+        if ( (energy < 0 || destroyed() || isCloaked() || isSafeZone()) && isLocal() )
+            Verb::Ref( new VerbGadgetOff( this ) );
+    }
+    else if ( m_pField.valid() )
+    {
+        m_pField->setLink( NULL );
+        m_pField = NULL;
+    }
 
-		energy -= energyCost();
-		if ( (energy < 0 || destroyed() || isCloaked() || isSafeZone()) && isLocal() )
-			Verb::Ref( new VerbGadgetOff( this ) );
-	}
-	else if ( m_pField.valid() )
-	{
-		detachNode( m_pField );
-		m_pField = NULL;
-	}
-
-	return energy;
+    return energy;
 }
 
 bool GadgetJD::updateLogic()
 {
-	if ( WidgetCast<NounShip>( parent() ) )
-	{
-		NounShip * pShip = (NounShip *)parent();
-		if ( !useActive() )
-			pShip->useGadget( this, NULL, false );
-		
-		return true;
-	}
-	else if ( WidgetCast<StructureDefense>( parent() ) )
-	{
-		StructureDefense * pStructure = (StructureDefense *)parent();
-		if ( pStructure->active() && !useActive() )
-			pStructure->useGadget( NULL, this );
-		else if ( !pStructure->active() && useActive() )
-			pStructure->useGadget( NULL, this );
+    if ( WidgetCast<NounShip>( parent() ) )
+    {
+        NounShip * pShip = (NounShip *)parent();
+        if ( !useActive() )
+            pShip->useGadget( this, NULL, false );
 
-		return true;
-	}
+        return true;
+    }
+    else if ( WidgetCast<StructureDefense>( parent() ) )
+    {
+        StructureDefense * pStructure = (StructureDefense *)parent();
+        if ( pStructure->active() && !useActive() )
+            pStructure->useGadget( NULL, this );        // turn on ECM 
+        else if ( !pStructure->active() && useActive() )
+            pStructure->useGadget( NULL, this );        // turn off ECM
 
-	return true;
-}
+        return true;
+    }
 
-float GadgetJD::addMass() const
-{
-	return active() ? 4.0f : 2.0f;
+    return true;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Community members have requested that planetary Interdictors function the way they did in previous versions. This is unedited code of the original working Interdictor that will restore that functionality. Also see changes in GadgetJD.h and FieldInterdictor.cpp