### PR TITLE
Set ship yaw accordingly to the keys the user is holding

### DIFF
--- a/Interface/ViewTactical.cpp
+++ b/Interface/ViewTactical.cpp
@@ -101,6 +101,7 @@ ViewTactical::ViewTactical() :
 	m_CameraZoomLevel = 3;
 
 	m_fYaw = m_fYawV = 0.0f;
+	YawStatePressed m_yawState = YawStatePressed::None;
 	m_SetHeading = m_SetHeadingV = 0.0f;
 	m_SetVelocity = m_SetVelocityV = 0.0f;
 	m_BeginControl = false;
@@ -780,8 +781,13 @@ bool ViewTactical::onMessage( const Message & msg )
 		case HK_LEFT:
 			if ( m_bYawControl )
 			{
-				if ( m_fYaw > -1.0f )
+				if ( m_yawState != YawStatePressed::Left && m_yawState != YawStatePressed::Both )
 				{
+					if (m_yawState == YawStatePressed::Right)
+						m_yawState = YawStatePressed::Both;
+					else
+						m_yawState = YawStatePressed::Left;
+
 					m_BeginControl = true;
 					m_UpdateControl = true;
 					m_fYaw = -1.0f;
@@ -796,9 +802,13 @@ bool ViewTactical::onMessage( const Message & msg )
 		case 'A':
 			if ( m_bYawControl )
 			{
-				if ( m_fYaw > -1.0f )
+				if ( m_yawState != YawStatePressed::Left && m_yawState != YawStatePressed::Both )
 				{
 					m_BeginControl = true;
+					if (m_yawState == YawStatePressed::Right)
+						m_yawState = YawStatePressed::Both;
+					else
+						m_yawState = YawStatePressed::Left;
 
 					m_fYawV = -SET_YAW_RATE;
 					if ( m_fYaw > 0.0f )
@@ -814,8 +824,13 @@ bool ViewTactical::onMessage( const Message & msg )
 		case HK_RIGHT:
 			if ( m_bYawControl )
 			{
-				if ( m_fYaw < 1.0f )
+				if ( m_yawState != YawStatePressed::Right && m_yawState != YawStatePressed::Both )
 				{
+					if (m_yawState == YawStatePressed::Left)
+						m_yawState = YawStatePressed::Both;
+					else
+						m_yawState = YawStatePressed::Right;
+
 					m_BeginControl = true;
 					m_UpdateControl = true;
 					m_fYaw = 1.0f;
@@ -830,9 +845,13 @@ bool ViewTactical::onMessage( const Message & msg )
 		case 'D':
 			if ( m_bYawControl )
 			{
-				if ( m_fYaw < 1.0f )
+				if ( m_yawState != YawStatePressed::Right && m_yawState != YawStatePressed::Both )
 				{
 					m_BeginControl = true;
+					if (m_yawState == YawStatePressed::Left)
+						m_yawState = YawStatePressed::Both;
+					else
+						m_yawState = YawStatePressed::Right;
 
 					m_fYawV = SET_YAW_RATE;
 					if ( m_fYaw < 0.0f )
@@ -880,19 +899,61 @@ bool ViewTactical::onMessage( const Message & msg )
 			}
 			return true;
 		case HK_LEFT:
+			if (m_yawState == YawStatePressed::Both) {
+				m_yawState = YawStatePressed::Right;
+				m_fYaw = 1.0f;
+				m_UpdateControl = true;
+			}
+			else if (m_yawState == YawStatePressed::Left) {
+				m_yawState = YawStatePressed::None;
+				m_fYaw = m_fYawV = 0.0f;
+				m_UpdateControl = true;
+			}
+			return true;
 		case HK_RIGHT:
-			if ( m_fYaw != 0.0f )
-			{
+			if (m_yawState == YawStatePressed::Both) {
+				m_yawState = YawStatePressed::Left;
+				m_fYaw = -1.0f;
+				m_UpdateControl = true;
+			}
+			else if (m_yawState == YawStatePressed::Right) {
+				m_yawState = YawStatePressed::None;
 				m_fYaw = m_fYawV = 0.0f;
 				m_UpdateControl = true;
 			}
 			return true;
 		case 'A':	
+			if (m_bYawControl) {
+				if (m_yawState == YawStatePressed::Both) {
+					m_yawState = YawStatePressed::Right;
+					m_fYawV = 1.0f;
+					m_UpdateControl = true;
+				}
+				else if (m_yawState == YawStatePressed::Left) {
+					m_yawState = YawStatePressed::None;
+					m_fYawV = 0.0f;
+					m_UpdateControl = true;
+				}
+			}
+			else
+			{
+				if ( m_SetHeadingV != 0.0f )
+				{
+					m_SetHeadingV = 0.0f;
+					m_UpdateControl = true;
+				}
+			}
+			return true;
 		case 'D':
 			if ( m_bYawControl )
 			{
-				if ( m_fYawV != 0.0f )
-				{
+				if (m_yawState == YawStatePressed::Both) {
+					m_yawState = YawStatePressed::Left;
+					m_fYawV = -1.0f;
+					m_UpdateControl = true;
+				}
+				else if (m_yawState == YawStatePressed::Right) {
+					m_yawState = YawStatePressed::None;
 					m_fYawV = 0.0f;
 					m_UpdateControl = true;
 				}

--- a/Interface/ViewTactical.h
+++ b/Interface/ViewTactical.h
@@ -22,6 +22,13 @@ class ViewGame;
 
 //----------------------------------------------------------------------------
 
+enum YawStatePressed {
+	None,
+	Left,
+	Right,
+	Both
+};
+
 class ViewTactical : public WindowView::View
 {
 public:
@@ -149,6 +156,7 @@ private:
 	bool				m_UpdateControl;	// ship manual controls
 	float				m_fYaw;
 	float				m_fYawV;
+	YawStatePressed		        m_yawState;
 	float				m_SetHeading;
 	float				m_SetHeadingV;
 	float				m_SetVelocity;		// desired ship velocity


### PR DESCRIPTION
This PR allows the ship of a player to correctly turn following which navigation keys are pressed or not. It uses an enum to maintain the current state.

Fixes #20 